### PR TITLE
Fix timestamp for general factor (for MySQL 8.0)

### DIFF
--- a/DataProviders/BoostingFactorDataProvider.php
+++ b/DataProviders/BoostingFactorDataProvider.php
@@ -49,7 +49,7 @@ class BoostingFactorDataProvider
             'boosterD' =>
                 [
                     'value' => $scopeConfig->getValue('bestsellers/boosting_factors/boosting_factor_general'),
-                    'max_days_old' => 999999999
+                    'max_days_old' => 36500
                 ]
         ];
     }


### PR DESCRIPTION
Setting max_days_old to 999999999 for general factor s causing SQL error at MySQL 8.0 and bestseller scores are not calculated by cron:

SQLSTATE[HY000]: General error: 1525 Incorrect TIMESTAMP value: '-2735886-02-04 00:00:00', query was: SELECT `sales_order_item`.`item_id`, `sales_order_item`.`qty_ordered`, `sales_order_item`.`product_id`, `sales_order_item`.`created_at`, `cataloginventory_stock_item`.`qty`, SUM(`sales_order_item`.qty_ordered) AS `sum_qty_ordered`, COUNT(`sales_order_item`.product_id) AS `count_ordered` FROM `sales_order_item` INNER JOIN `cataloginventory_stock_item` ON cataloginventory_stock_item.product_id = 102000 WHERE (sales_order_item.product_id = '102000') AND (created_at >= '2020-02-05 00:00:00') AND (created_at >= '-2735886-02-04 00:00:00') AND (created_at <= '2020-02-06 23:59:59') GROUP BY `product_id`